### PR TITLE
Set new formatting rule as warning: `object-shorthand`

### DIFF
--- a/src/configs/base/rules/index.js
+++ b/src/configs/base/rules/index.js
@@ -42,6 +42,9 @@ export default {
     },
   ],
 
+  // https://eslint.org/docs/rules/object-shorthand
+  'object-shorthand': 'warn',
+
   // https://eslint.org/docs/rules/prefer-arrow-callback
   'prefer-arrow-callback': 'error',
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated code style checks to suggest using shorthand syntax for object literals, with warnings for non-shorthand usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->