### PR TITLE
Fix plugin path resolution for prettier-jsdoc using require.resolve()

### DIFF
--- a/src/configs/prettier/index.js
+++ b/src/configs/prettier/index.js
@@ -1,5 +1,9 @@
 import prettierConfigAndPlugin from 'eslint-plugin-prettier/recommended';
 import { defineConfig } from 'eslint/config';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const prettierPluginJsdocPath = require.resolve('prettier-plugin-jsdoc');
 
 export default defineConfig([
   prettierConfigAndPlugin,
@@ -8,7 +12,7 @@ export default defineConfig([
       'prettier/prettier': [
         'warn',
         {
-          plugins: ['prettier-plugin-jsdoc'],
+          plugins: [prettierPluginJsdocPath],
           jsdocCommentLineStrategy: 'multiline',
           jsdocDescriptionWithDot: true,
           jsdocPrintWidth: 80,


### PR DESCRIPTION
Resolves #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dynamic resolution of code formatting plugin dependencies for enhanced configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->